### PR TITLE
Fix error handling when an invalid pin name is provided

### DIFF
--- a/include/beaglebone/BeagleGoo.h
+++ b/include/beaglebone/BeagleGoo.h
@@ -30,6 +30,7 @@ class BeagleGoo: public GPIOoo
 
 		bool active;
 		static struct GPIOInfo gpioInfos[];
+		static size_t gpioCount;
 		static uint16_t addrs[];
 		int gpioFd;
 		uint32_t *gpios[4];

--- a/src/BeagleGoo.cpp
+++ b/src/BeagleGoo.cpp
@@ -92,6 +92,8 @@ struct BeagleGoo::GPIOInfo BeagleGoo::gpioInfos[] =
 		{ (char*) "P9_41", 0, 20, 0, 0 },
 		{ (char*) "P9_42", 0, 7, 0, 0 } };
 
+size_t BeagleGoo::gpioCount = sizeof(BeagleGoo::gpioInfos) / sizeof(BeagleGoo::GPIOInfo);
+
 uint16_t BeagleGoo::addrs[] =
 	{ 0x0818, 0x081C, 0x0808,	                //p8_4, p8_5
 			0x080C, 0x0890, 0x0894, 0x089C, 0x0898, //p8_6 .. p8_10
@@ -161,7 +163,7 @@ GPIOpin *BeagleGoo::claim(char* names[], int num, gpioWriteSemantics semantics,
 		pininfos[i] = _findGpio(names[i]);
 		if (pininfos[i] == NULL)
 		{
-			debug(1, "Pin '%s' not found\n", names[i]);
+			debug(1, "Pin '%s' is not a valid GPIO pin\n", names[i]);
 			delete[] pininfos;
 			return NULL;
 		}
@@ -200,7 +202,7 @@ GPIOpin *BeagleGoo::claim(char* names[], int num, gpioWriteSemantics semantics,
 
 struct BeagleGoo::GPIOInfo* BeagleGoo::_findGpio(char* name)
 {
-	for (int i = 0; gpioInfos[i].name != NULL; i++)
+	for (unsigned int i = 0; i < gpioCount; i++)
 		if (strncmp(gpioInfos[i].name, name, MaxGpioNameLen) == 0)
 			return (struct GPIOInfo *) &gpioInfos[i];
 	debug(0, "BeagleGoo::_findGpio(): pin %s not found\n", name);


### PR DESCRIPTION
If, for example, the ADC pin "P9_33" is provided, a segmentation fault would occur due to improper name searching code. This is now fixed with an improved error message.
