### PR TITLE
dts/Makefile.am: remove invalid target

### DIFF
--- a/dts/Makefile.am
+++ b/dts/Makefile.am
@@ -1,6 +1,6 @@
 
 
-DTS=gpio_hd44780-00A0.dts gpio_leds-00A0.dts tlc5946-00A0.dts gpio_buttons-00A0.dts spi1-00A0.dts jd-t18003-ctrl-00A0.dts
+DTS=gpio_hd44780-00A0.dts gpio_leds-00A0.dts tlc5946-00A0.dts gpio_buttons-00A0.dts jd-t18003-ctrl-00A0.dts
 DTBs=$(patsubst %.dts,%.dtbo,$(DTS))
 
 %.dtbo: %.dts


### PR DESCRIPTION
This came up on creating recipe for yocto.
